### PR TITLE
added match-id in view

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -176,9 +176,9 @@ func (m Model) View() string {
 	if m.selectedMatch < len(m.app.Matches) {
 		match := m.app.Matches[m.selectedMatch]
 		content.WriteString(m.renderMatchInfo(match))
-  	var match_id = fmt.Sprintf("Match id : %d", match.CricbuzzMatchID)
-  	content.WriteString(helpStyle.Render(match_id))
-  	content.WriteString("\n")
+		var match_id = fmt.Sprintf("Match id : %d", match.CricbuzzMatchID)
+		content.WriteString(helpStyle.Render(match_id))
+		content.WriteString("\n")
 	}
 
 	// Help


### PR DESCRIPTION
Enhancement : Added match-id in view, so that we don't have to go to cricbuzz website to look for the match-id use it in the crictty --match-id <id>. I can see the match id in all match view and use that if i want to see a particular match.

Solves the whole problem of leaving the terminal

Issue : https://github.com/ashish0kumar/crictty/issues/2

<img width="723" alt="image" src="https://github.com/user-attachments/assets/5201918f-6200-4522-982e-8d6de4d44ad2" />
